### PR TITLE
Add bash completion for common dev-lxc subcommands on containers in cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dev-lxc-platform Change Log
 
+## Unreleased
+
+* Add bash completion for common subcommands on container names
+
 ## 2.0.1 (2015-12-09)
 
 * Install Sysdig in Ubuntu VM

--- a/files/default/bash-completion-dev-lxc
+++ b/files/default/bash-completion-dev-lxc
@@ -1,0 +1,36 @@
+_dev-lxc()
+{
+    shopt -s extglob
+
+    local cur prev opts base
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    #
+    #  The basic options we'll complete.
+    #
+    opts="attach destroy halt list-images realpath run-command snapshot status up"
+
+    #replace spaces and place in extglob format
+    pipeopts="@(`echo $opts | sed 's/ /|/g'`)"
+
+    #
+    #  Complete the arguments to some of the basic commands.
+    #
+    case "${prev}" in
+        $pipeopts)
+            local names=`dev-lxc list-images | grep Final | awk  '{ print $NF }'`
+            COMPREPLY=( $(compgen -W "${names}" -- ${cur}) )
+            return 0
+            ;;
+        *)
+        ;;
+    esac
+
+   COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+   return 0
+}
+
+complete -F _dev-lxc dev-lxc
+complete -F _dev-lxc dl

--- a/recipes/lxc-helpful-addons.rb
+++ b/recipes/lxc-helpful-addons.rb
@@ -63,3 +63,10 @@ cookbook_file '/usr/local/bin/containers-view' do
   group 'root'
   mode 0755
 end
+
+cookbook_file '/etc/bash_completion.d/dev-lxc' do
+  source 'bash-completion-dev-lxc'
+  owner 'root'
+  group 'root'
+  mode 0755
+end


### PR DESCRIPTION
Update with full command and include cookbook_file
so that something actually happens with kitchen converge
